### PR TITLE
chore: move the sessionId to the root of the event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@loopkit/javascript",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "description": "JavaScript SDK for LoopKit analytics platform",
     "type": "module",
     "main": "dist/loopkit.cjs.js",

--- a/src/core/EventTracker.ts
+++ b/src/core/EventTracker.ts
@@ -187,6 +187,7 @@ export class EventTracker {
 
     return {
       anonymousId: this.sessionManager.getAnonymousId(),
+      sessionId: this.sessionManager.getSessionId(),
       timestamp: now,
       system: this.createSystemInfo(),
     };
@@ -201,7 +202,6 @@ export class EventTracker {
         name: '@loopkit/javascript',
         version: typeof __VERSION__ !== 'undefined' ? __VERSION__ : '1.0.5',
       },
-      sessionId: this.sessionManager.getSessionId(),
     };
 
     // Add browser context if in browser environment

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,6 +62,8 @@ export type RetryBackoff = 'exponential' | 'linear';
 export interface BaseEvent {
   /** Unique anonymous identifier */
   anonymousId: string;
+  /** Session ID */
+  sessionId: string;
   /** ISO 8601 timestamp */
   timestamp: string;
   /** User ID (if identified) */
@@ -113,8 +115,6 @@ export interface SystemInfo {
     name: string;
     version: string;
   };
-  /** Session ID */
-  sessionId: string;
   /** Browser/environment context */
   context?: ContextInfo;
 }

--- a/tests/loopkit.test.js
+++ b/tests/loopkit.test.js
@@ -530,6 +530,9 @@ describe('LoopKit SDK', () => {
       expect(event).toHaveProperty('anonymousId');
       expect(typeof event.anonymousId).toBe('string');
 
+      expect(event).toHaveProperty('sessionId');
+      expect(typeof event.sessionId).toBe('string');
+
       expect(event).toHaveProperty('timestamp');
       expect(typeof event.timestamp).toBe('string');
       // Verify ISO 8601 format
@@ -549,9 +552,6 @@ describe('LoopKit SDK', () => {
       expect(event.system.sdk).toHaveProperty('name', '@loopkit/javascript');
       expect(event.system.sdk).toHaveProperty('version');
       expect(typeof event.system.sdk.version).toBe('string');
-
-      expect(event.system).toHaveProperty('sessionId');
-      expect(typeof event.system.sessionId).toBe('string');
 
       // Context should be present in browser environment (jsdom)
       expect(event.system).toHaveProperty('context');


### PR DESCRIPTION
### Background

The `sessionId` is a critical identifier, used for associating many events together. By moving the property to the root of the event, we greatly simplify down stream usage/consumption. 

### Summary
* Move `sessionId` to the root of the event.

